### PR TITLE
fix: 개별서버 실행 및 전체 서버 실행 구현

### DIFF
--- a/apps/ai-service/package.json
+++ b/apps/ai-service/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "cd ../.. && nx run ai-service:serve:development",
-    "build": "cd ../.. && nx run ai-service:build:development",
+    "build:dev": "cd ../.. && nx run ai-service:build:development",
+    "build:prod": "cd ../.. && nx run ai-service:build:production",
+    "start": "cd ../.. && nx run api-gateway:serve:production && nx run ai-service:serve:production",
     "test": "cd ../.. && nx test ai-service"
   }
 }

--- a/apps/ai-service/package.json
+++ b/apps/ai-service/package.json
@@ -3,78 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "nx run @fundmate-be/ai-service:serve",
-    "build": "nx run @fundmate-be/ai-service:build",
-    "test": "nx run @fundmate-be/ai-service:test"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "@nx/esbuild:esbuild",
-        "outputs": [
-          "{options.outputPath}"
-        ],
-        "defaultConfiguration": "production",
-        "options": {
-          "platform": "node",
-          "outputPath": "apps/ai-service/dist",
-          "format": [
-            "cjs"
-          ],
-          "bundle": false,
-          "main": "apps/ai-service/src/main.ts",
-          "tsConfig": "apps/ai-service/tsconfig.app.json",
-          "assets": [
-            "apps/ai-service/src/assets"
-          ],
-          "esbuildOptions": {
-            "sourcemap": true,
-            "outExtension": {
-              ".js": ".js"
-            }
-          }
-        },
-        "configurations": {
-          "development": {},
-          "production": {
-            "esbuildOptions": {
-              "sourcemap": false,
-              "outExtension": {
-                ".js": ".js"
-              }
-            }
-          }
-        }
-      },
-      "serve": {
-        "continuous": true,
-        "executor": "@nx/js:node",
-        "defaultConfiguration": "development",
-        "dependsOn": [
-          "build"
-        ],
-        "options": {
-          "buildTarget": "@fundmate-be/ai-service:build",
-          "runBuildTargetDependencies": false
-        },
-        "configurations": {
-          "development": {
-            "buildTarget": "@fundmate-be/ai-service:build:development"
-          },
-          "production": {
-            "buildTarget": "@fundmate-be/ai-service:build:production"
-          }
-        }
-      },
-      "test": {
-        "options": {
-          "passWithNoTests": true
-        }
-      }
-    },
-    "tags": [
-      "type:app",
-      "scope:ai"
-    ]
+    "dev": "cd ../.. && nx run ai-service:serve:development",
+    "build": "cd ../.. && nx run ai-service:build:development",
+    "test": "cd ../.. && nx test ai-service"
   }
 }

--- a/apps/ai-service/project.json
+++ b/apps/ai-service/project.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "ai-service",
+  "sourceRoot": "apps/ai-service/src",
+  "projectType": "application",
+  "tags": ["type:app", "scope:ai"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "apps/ai-service/dist",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/ai-service/src/main.ts",
+        "tsConfig": "apps/ai-service/tsconfig.app.json",
+        "assets": ["apps/ai-service/src/assets"]
+      },
+      "configurations": {
+        "development": {
+          "esbuildOptions": {
+            "sourcemap": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "production",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "ai-service:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "ai-service:build:development",
+          "watch": true
+        },
+        "production": {
+          "buildTarget": "ai-service:build:production",
+          "watch": false,
+          "inspect": false
+        }
+      }
+    },
+    "test": {
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "cd ../.. && nx run api-gateway:serve:development",
-    "build": "cd ../.. && nx run api-gateway:build:development",
+    "build:dev": "cd ../.. && nx run api-gateway:build:development",
+    "build:prod": "cd ../.. && nx run api-gateway:build:production",
+    "start": "cd ../.. && nx run api-gateway:serve:production && nx run api-gateway:serve:production",
     "test": "cd ../.. && nx test api-gateway"
   }
 }

--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -3,78 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "nx run @fundmate-be/api-gateway:serve",
-    "build": "nx run @fundmate-be/api-gateway:build",
-    "test": "nx run @fundmate-be/api-gateway:test"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "@nx/esbuild:esbuild",
-        "outputs": [
-          "{options.outputPath}"
-        ],
-        "defaultConfiguration": "production",
-        "options": {
-          "platform": "node",
-          "outputPath": "apps/api-gateway/dist",
-          "format": [
-            "cjs"
-          ],
-          "bundle": false,
-          "main": "apps/api-gateway/src/main.ts",
-          "tsConfig": "apps/api-gateway/tsconfig.app.json",
-          "assets": [
-            "apps/api-gateway/src/assets"
-          ],
-          "esbuildOptions": {
-            "sourcemap": true,
-            "outExtension": {
-              ".js": ".js"
-            }
-          }
-        },
-        "configurations": {
-          "development": {},
-          "production": {
-            "esbuildOptions": {
-              "sourcemap": false,
-              "outExtension": {
-                ".js": ".js"
-              }
-            }
-          }
-        }
-      },
-      "serve": {
-        "continuous": true,
-        "executor": "@nx/js:node",
-        "defaultConfiguration": "development",
-        "dependsOn": [
-          "build"
-        ],
-        "options": {
-          "buildTarget": "@fundmate-be/api-gateway:build",
-          "runBuildTargetDependencies": false
-        },
-        "configurations": {
-          "development": {
-            "buildTarget": "@fundmate-be/api-gateway:build:development"
-          },
-          "production": {
-            "buildTarget": "@fundmate-be/api-gateway:build:production"
-          }
-        }
-      },
-      "test": {
-        "options": {
-          "passWithNoTests": true
-        }
-      }
-    },
-    "tags": [
-      "type:app",
-      "scope:gateway"
-    ]
+    "dev": "cd ../.. && nx run api-gateway:serve:development",
+    "build": "cd ../.. && nx run api-gateway:build:development",
+    "test": "cd ../.. && nx test api-gateway"
   }
 }

--- a/apps/api-gateway/project.json
+++ b/apps/api-gateway/project.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "api-gateway",
+  "sourceRoot": "apps/api-gateway/src",
+  "projectType": "application",
+  "tags": ["type:app", "scope:ai"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "apps/api-gateway/dist",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/api-gateway/src/main.ts",
+        "tsConfig": "apps/api-gateway/tsconfig.app.json",
+        "assets": ["apps/api-gateway/src/assets"]
+      },
+      "configurations": {
+        "development": {
+          "esbuildOptions": {
+            "sourcemap": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "production",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "api-gateway:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "api-gateway:build:development",
+          "watch": true
+        },
+        "production": {
+          "buildTarget": "api-gateway:build:production",
+          "watch": false,
+          "inspect": false
+        }
+      }
+    },
+    "test": {
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/apps/api-gateway/project.json
+++ b/apps/api-gateway/project.json
@@ -3,7 +3,7 @@
   "name": "api-gateway",
   "sourceRoot": "apps/api-gateway/src",
   "projectType": "application",
-  "tags": ["type:app", "scope:ai"],
+  "tags": ["type:app", "scope:gateway"],
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",

--- a/apps/auth-service/package.json
+++ b/apps/auth-service/package.json
@@ -3,78 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "nx run @fundmate-be/auth-service:serve",
-    "build": "nx run @fundmate-be/auth-service:build",
-    "test": "nx run @fundmate-be/auth-service:test"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "@nx/esbuild:esbuild",
-        "outputs": [
-          "{options.outputPath}"
-        ],
-        "defaultConfiguration": "production",
-        "options": {
-          "platform": "node",
-          "outputPath": "apps/auth-service/dist",
-          "format": [
-            "cjs"
-          ],
-          "bundle": false,
-          "main": "apps/auth-service/src/main.ts",
-          "tsConfig": "apps/auth-service/tsconfig.app.json",
-          "assets": [
-            "apps/auth-service/src/assets"
-          ],
-          "esbuildOptions": {
-            "sourcemap": true,
-            "outExtension": {
-              ".js": ".js"
-            }
-          }
-        },
-        "configurations": {
-          "development": {},
-          "production": {
-            "esbuildOptions": {
-              "sourcemap": false,
-              "outExtension": {
-                ".js": ".js"
-              }
-            }
-          }
-        }
-      },
-      "serve": {
-        "continuous": true,
-        "executor": "@nx/js:node",
-        "defaultConfiguration": "development",
-        "dependsOn": [
-          "build"
-        ],
-        "options": {
-          "buildTarget": "@fundmate-be/auth-service:build",
-          "runBuildTargetDependencies": false
-        },
-        "configurations": {
-          "development": {
-            "buildTarget": "@fundmate-be/auth-service:build:development"
-          },
-          "production": {
-            "buildTarget": "@fundmate-be/auth-service:build:production"
-          }
-        }
-      },
-      "test": {
-        "options": {
-          "passWithNoTests": true
-        }
-      }
-    },
-    "tags": [
-      "type:app",
-      "scope:auth"
-    ]
+    "dev": "cd ../.. && nx run auth-service:serve:development",
+    "build": "cd ../.. && nx run auth-service:build:development",
+    "test": "cd ../.. && nx test auth-service"
   }
 }

--- a/apps/auth-service/package.json
+++ b/apps/auth-service/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "cd ../.. && nx run auth-service:serve:development",
-    "build": "cd ../.. && nx run auth-service:build:development",
+    "build:dev": "cd ../.. && nx run auth-service:build:development",
+    "build:prod": "cd ../.. && nx run auth-service:build:production",
+    "start": "cd ../.. && nx run api-gateway:serve:production && nx run auth-service:serve:production",
     "test": "cd ../.. && nx test auth-service"
   }
 }

--- a/apps/auth-service/project.json
+++ b/apps/auth-service/project.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "auth-service",
+  "sourceRoot": "apps/auth-service/src",
+  "projectType": "application",
+  "tags": ["type:app", "scope:ai"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "apps/auth-service/dist",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/auth-service/src/main.ts",
+        "tsConfig": "apps/auth-service/tsconfig.app.json",
+        "assets": ["apps/auth-service/src/assets"]
+      },
+      "configurations": {
+        "development": {
+          "esbuildOptions": {
+            "sourcemap": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "production",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "auth-service:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "auth-service:build:development",
+          "watch": true
+        },
+        "production": {
+          "buildTarget": "auth-service:build:production",
+          "watch": false,
+          "inspect": false
+        }
+      }
+    },
+    "test": {
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/apps/auth-service/project.json
+++ b/apps/auth-service/project.json
@@ -3,7 +3,7 @@
   "name": "auth-service",
   "sourceRoot": "apps/auth-service/src",
   "projectType": "application",
-  "tags": ["type:app", "scope:ai"],
+  "tags": ["type:app", "scope:auth"],
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",

--- a/apps/funding-service/package.json
+++ b/apps/funding-service/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "cd ../.. && nx run funding-service:serve:development",
-    "build": "cd ../.. && nx run funding-service:build:development",
+    "build:dev": "cd ../.. && nx run funding-service:build:development",
+    "build:prod": "cd ../.. && nx run funding-service:build:production",
+    "start": "cd ../.. && nx run api-gateway:serve:production && nx run funding-service:serve:production",
     "test": "cd ../.. && nx test funding-service"
   }
 }

--- a/apps/funding-service/package.json
+++ b/apps/funding-service/package.json
@@ -3,78 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "nx run @fundmate-be/funding-service:serve",
-    "build": "nx run @fundmate-be/funding-service:build",
-    "test": "nx run @fundmate-be/funding-service:test"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "@nx/esbuild:esbuild",
-        "outputs": [
-          "{options.outputPath}"
-        ],
-        "defaultConfiguration": "production",
-        "options": {
-          "platform": "node",
-          "outputPath": "apps/funding-service/dist",
-          "format": [
-            "cjs"
-          ],
-          "bundle": false,
-          "main": "apps/funding-service/src/main.ts",
-          "tsConfig": "apps/funding-service/tsconfig.app.json",
-          "assets": [
-            "apps/funding-service/src/assets"
-          ],
-          "esbuildOptions": {
-            "sourcemap": true,
-            "outExtension": {
-              ".js": ".js"
-            }
-          }
-        },
-        "configurations": {
-          "development": {},
-          "production": {
-            "esbuildOptions": {
-              "sourcemap": false,
-              "outExtension": {
-                ".js": ".js"
-              }
-            }
-          }
-        }
-      },
-      "serve": {
-        "continuous": true,
-        "executor": "@nx/js:node",
-        "defaultConfiguration": "development",
-        "dependsOn": [
-          "build"
-        ],
-        "options": {
-          "buildTarget": "@fundmate-be/funding-service:build",
-          "runBuildTargetDependencies": false
-        },
-        "configurations": {
-          "development": {
-            "buildTarget": "@fundmate-be/funding-service:build:development"
-          },
-          "production": {
-            "buildTarget": "@fundmate-be/funding-service:build:production"
-          }
-        }
-      },
-      "test": {
-        "options": {
-          "passWithNoTests": true
-        }
-      }
-    },
-    "tags": [
-      "type:app",
-      "scope:funding"
-    ]
+    "dev": "cd ../.. && nx run funding-service:serve:development",
+    "build": "cd ../.. && nx run funding-service:build:development",
+    "test": "cd ../.. && nx test funding-service"
   }
 }

--- a/apps/funding-service/project.json
+++ b/apps/funding-service/project.json
@@ -3,7 +3,7 @@
   "name": "funding-service",
   "sourceRoot": "apps/funding-service/src",
   "projectType": "application",
-  "tags": ["type:app", "scope:ai"],
+  "tags": ["type:app", "scope:funding"],
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",

--- a/apps/funding-service/project.json
+++ b/apps/funding-service/project.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "funding-service",
+  "sourceRoot": "apps/funding-service/src",
+  "projectType": "application",
+  "tags": ["type:app", "scope:ai"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "apps/funding-service/dist",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/funding-service/src/main.ts",
+        "tsConfig": "apps/funding-service/tsconfig.app.json",
+        "assets": ["apps/funding-service/src/assets"]
+      },
+      "configurations": {
+        "development": {
+          "esbuildOptions": {
+            "sourcemap": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "production",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "funding-service:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "funding-service:build:development",
+          "watch": true
+        },
+        "production": {
+          "buildTarget": "funding-service:build:production",
+          "watch": false,
+          "inspect": false
+        }
+      }
+    },
+    "test": {
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/apps/interaction-service/package.json
+++ b/apps/interaction-service/package.json
@@ -3,78 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "nx run @fundmate-be/interaction-service:serve",
-    "build": "nx run @fundmate-be/interaction-service:build",
-    "test": "nx run @fundmate-be/interaction-service:test"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "@nx/esbuild:esbuild",
-        "outputs": [
-          "{options.outputPath}"
-        ],
-        "defaultConfiguration": "production",
-        "options": {
-          "platform": "node",
-          "outputPath": "apps/interaction-service/dist",
-          "format": [
-            "cjs"
-          ],
-          "bundle": false,
-          "main": "apps/interaction-service/src/main.ts",
-          "tsConfig": "apps/interaction-service/tsconfig.app.json",
-          "assets": [
-            "apps/interaction-service/src/assets"
-          ],
-          "esbuildOptions": {
-            "sourcemap": true,
-            "outExtension": {
-              ".js": ".js"
-            }
-          }
-        },
-        "configurations": {
-          "development": {},
-          "production": {
-            "esbuildOptions": {
-              "sourcemap": false,
-              "outExtension": {
-                ".js": ".js"
-              }
-            }
-          }
-        }
-      },
-      "serve": {
-        "continuous": true,
-        "executor": "@nx/js:node",
-        "defaultConfiguration": "development",
-        "dependsOn": [
-          "build"
-        ],
-        "options": {
-          "buildTarget": "@fundmate-be/interaction-service:build",
-          "runBuildTargetDependencies": false
-        },
-        "configurations": {
-          "development": {
-            "buildTarget": "@fundmate-be/interaction-service:build:development"
-          },
-          "production": {
-            "buildTarget": "@fundmate-be/interaction-service:build:production"
-          }
-        }
-      },
-      "test": {
-        "options": {
-          "passWithNoTests": true
-        }
-      }
-    },
-    "tags": [
-      "type:app",
-      "scope:interaction"
-    ]
+    "dev": "cd ../.. && nx run interaction-service:serve:development",
+    "build": "cd ../.. && nx run interaction-service:build:development",
+    "test": "cd ../.. && nx test interaction-service"
   }
 }

--- a/apps/interaction-service/package.json
+++ b/apps/interaction-service/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "cd ../.. && nx run interaction-service:serve:development",
-    "build": "cd ../.. && nx run interaction-service:build:development",
+    "build:dev": "cd ../.. && nx run interaction-service:build:development",
+    "build:prod": "cd ../.. && nx run interaction-service:build:production",
+    "start": "cd ../.. && nx run api-gateway:serve:production && nx run interaction-service:serve:production",
     "test": "cd ../.. && nx test interaction-service"
   }
 }

--- a/apps/interaction-service/project.json
+++ b/apps/interaction-service/project.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "interaction-service",
+  "sourceRoot": "apps/interaction-service/src",
+  "projectType": "application",
+  "tags": ["type:app", "scope:ai"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "apps/interaction-service/dist",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/interaction-service/src/main.ts",
+        "tsConfig": "apps/interaction-service/tsconfig.app.json",
+        "assets": ["apps/interaction-service/src/assets"]
+      },
+      "configurations": {
+        "development": {
+          "esbuildOptions": {
+            "sourcemap": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "production",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "interaction-service:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "interaction-service:build:development",
+          "watch": true
+        },
+        "production": {
+          "buildTarget": "interaction-service:build:production",
+          "watch": false,
+          "inspect": false
+        }
+      }
+    },
+    "test": {
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/apps/interaction-service/project.json
+++ b/apps/interaction-service/project.json
@@ -3,7 +3,7 @@
   "name": "interaction-service",
   "sourceRoot": "apps/interaction-service/src",
   "projectType": "application",
-  "tags": ["type:app", "scope:ai"],
+  "tags": ["type:app", "scope:interaction"],
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",

--- a/apps/payment-service/package.json
+++ b/apps/payment-service/package.json
@@ -3,78 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "nx run @fundmate-be/payment-service:serve",
-    "build": "nx run @fundmate-be/payment-service:build",
-    "test": "nx run @fundmate-be/payment-service:test"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "@nx/esbuild:esbuild",
-        "outputs": [
-          "{options.outputPath}"
-        ],
-        "defaultConfiguration": "production",
-        "options": {
-          "platform": "node",
-          "outputPath": "apps/payment-service/dist",
-          "format": [
-            "cjs"
-          ],
-          "bundle": false,
-          "main": "apps/payment-service/src/main.ts",
-          "tsConfig": "apps/payment-service/tsconfig.app.json",
-          "assets": [
-            "apps/payment-service/src/assets"
-          ],
-          "esbuildOptions": {
-            "sourcemap": true,
-            "outExtension": {
-              ".js": ".js"
-            }
-          }
-        },
-        "configurations": {
-          "development": {},
-          "production": {
-            "esbuildOptions": {
-              "sourcemap": false,
-              "outExtension": {
-                ".js": ".js"
-              }
-            }
-          }
-        }
-      },
-      "serve": {
-        "continuous": true,
-        "executor": "@nx/js:node",
-        "defaultConfiguration": "development",
-        "dependsOn": [
-          "build"
-        ],
-        "options": {
-          "buildTarget": "@fundmate-be/payment-service:build",
-          "runBuildTargetDependencies": false
-        },
-        "configurations": {
-          "development": {
-            "buildTarget": "@fundmate-be/payment-service:build:development"
-          },
-          "production": {
-            "buildTarget": "@fundmate-be/payment-service:build:production"
-          }
-        }
-      },
-      "test": {
-        "options": {
-          "passWithNoTests": true
-        }
-      }
-    },
-    "tags": [
-      "type:app",
-      "scope:payment"
-    ]
+    "dev": "cd ../.. && nx run payment-service:serve:development",
+    "build": "cd ../.. && nx run payment-service:build:development",
+    "test": "cd ../.. && nx test payment-service"
   }
 }

--- a/apps/payment-service/package.json
+++ b/apps/payment-service/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "cd ../.. && nx run payment-service:serve:development",
-    "build": "cd ../.. && nx run payment-service:build:development",
+    "build:dev": "cd ../.. && nx run payment-service:build:development",
+    "build:prod": "cd ../.. && nx run payment-service:build:production",
+    "start": "cd ../.. && nx run api-gateway:serve:production && nx run payment-service:serve:production",
     "test": "cd ../.. && nx test payment-service"
   }
 }

--- a/apps/payment-service/project.json
+++ b/apps/payment-service/project.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "payment-service",
+  "sourceRoot": "apps/payment-service/src",
+  "projectType": "application",
+  "tags": ["type:app", "scope:ai"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "apps/payment-service/dist",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/payment-service/src/main.ts",
+        "tsConfig": "apps/payment-service/tsconfig.app.json",
+        "assets": ["apps/payment-service/src/assets"]
+      },
+      "configurations": {
+        "development": {
+          "esbuildOptions": {
+            "sourcemap": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "production",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "payment-service:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "payment-service:build:development",
+          "watch": true
+        },
+        "production": {
+          "buildTarget": "payment-service:build:production",
+          "watch": false,
+          "inspect": false
+        }
+      }
+    },
+    "test": {
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/apps/payment-service/project.json
+++ b/apps/payment-service/project.json
@@ -3,7 +3,7 @@
   "name": "payment-service",
   "sourceRoot": "apps/payment-service/src",
   "projectType": "application",
-  "tags": ["type:app", "scope:ai"],
+  "tags": ["type:app", "scope:payment"],
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",

--- a/apps/public-service/package.json
+++ b/apps/public-service/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "cd ../.. && nx run public-service:serve:development",
-    "build": "cd ../.. && nx run public-service:build:development",
+    "build:dev": "cd ../.. && nx run public-service:build:development",
+    "build:prod": "cd ../.. && nx run public-service:build:production",
+    "start": "cd ../.. && nx run api-gateway:serve:production && nx run public-service:serve:production",
     "test": "cd ../.. && nx test public-service"
   }
 }

--- a/apps/public-service/package.json
+++ b/apps/public-service/package.json
@@ -3,78 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "nx run @fundmate-be/public-service:serve",
-    "build": "nx run @fundmate-be/public-service:build",
-    "test": "nx run @fundmate-be/public-service:test"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "@nx/esbuild:esbuild",
-        "outputs": [
-          "{options.outputPath}"
-        ],
-        "defaultConfiguration": "production",
-        "options": {
-          "platform": "node",
-          "outputPath": "apps/public-service/dist",
-          "format": [
-            "cjs"
-          ],
-          "bundle": false,
-          "main": "apps/public-service/src/main.ts",
-          "tsConfig": "apps/public-service/tsconfig.app.json",
-          "assets": [
-            "apps/public-service/src/assets"
-          ],
-          "esbuildOptions": {
-            "sourcemap": true,
-            "outExtension": {
-              ".js": ".js"
-            }
-          }
-        },
-        "configurations": {
-          "development": {},
-          "production": {
-            "esbuildOptions": {
-              "sourcemap": false,
-              "outExtension": {
-                ".js": ".js"
-              }
-            }
-          }
-        }
-      },
-      "serve": {
-        "continuous": true,
-        "executor": "@nx/js:node",
-        "defaultConfiguration": "development",
-        "dependsOn": [
-          "build"
-        ],
-        "options": {
-          "buildTarget": "@fundmate-be/public-service:build",
-          "runBuildTargetDependencies": false
-        },
-        "configurations": {
-          "development": {
-            "buildTarget": "@fundmate-be/public-service:build:development"
-          },
-          "production": {
-            "buildTarget": "@fundmate-be/public-service:build:production"
-          }
-        }
-      },
-      "test": {
-        "options": {
-          "passWithNoTests": true
-        }
-      }
-    },
-    "tags": [
-      "type:app",
-      "scope:public"
-    ]
+    "dev": "cd ../.. && nx run public-service:serve:development",
+    "build": "cd ../.. && nx run public-service:build:development",
+    "test": "cd ../.. && nx test public-service"
   }
 }

--- a/apps/public-service/project.json
+++ b/apps/public-service/project.json
@@ -3,7 +3,7 @@
   "name": "public-service",
   "sourceRoot": "apps/public-service/src",
   "projectType": "application",
-  "tags": ["type:app", "scope:ai"],
+  "tags": ["type:app", "scope:public"],
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",

--- a/apps/public-service/project.json
+++ b/apps/public-service/project.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "public-service",
+  "sourceRoot": "apps/public-service/src",
+  "projectType": "application",
+  "tags": ["type:app", "scope:ai"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "apps/public-service/dist",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/public-service/src/main.ts",
+        "tsConfig": "apps/public-service/tsconfig.app.json",
+        "assets": ["apps/public-service/src/assets"]
+      },
+      "configurations": {
+        "development": {
+          "esbuildOptions": {
+            "sourcemap": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "production",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "public-service:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "public-service:build:development",
+          "watch": true
+        },
+        "production": {
+          "buildTarget": "public-service:build:production",
+          "watch": false,
+          "inspect": false
+        }
+      }
+    },
+    "test": {
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/apps/user-service/package.json
+++ b/apps/user-service/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "cd ../.. && nx run user-service:serve:development",
-    "build": "cd ../.. && nx run user-service:build:development",
+    "build:dev": "cd ../.. && nx run user-service:build:development",
+    "build:prod": "cd ../.. && nx run user-service:build:production",
+    "start": "cd ../.. && nx run api-gateway:serve:production && nx run user-service:serve:production",
     "test": "cd ../.. && nx test user-service"
   }
 }

--- a/apps/user-service/package.json
+++ b/apps/user-service/package.json
@@ -3,78 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "nx run @fundmate-be/user-service:serve",
-    "build": "nx run @fundmate-be/user-service:build",
-    "test": "nx run @fundmate-be/user-service:test"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "@nx/esbuild:esbuild",
-        "outputs": [
-          "{options.outputPath}"
-        ],
-        "defaultConfiguration": "production",
-        "options": {
-          "platform": "node",
-          "outputPath": "apps/user-service/dist",
-          "format": [
-            "cjs"
-          ],
-          "bundle": false,
-          "main": "apps/user-service/src/main.ts",
-          "tsConfig": "apps/user-service/tsconfig.app.json",
-          "assets": [
-            "apps/user-service/src/assets"
-          ],
-          "esbuildOptions": {
-            "sourcemap": true,
-            "outExtension": {
-              ".js": ".js"
-            }
-          }
-        },
-        "configurations": {
-          "development": {},
-          "production": {
-            "esbuildOptions": {
-              "sourcemap": false,
-              "outExtension": {
-                ".js": ".js"
-              }
-            }
-          }
-        }
-      },
-      "serve": {
-        "continuous": true,
-        "executor": "@nx/js:node",
-        "defaultConfiguration": "development",
-        "dependsOn": [
-          "build"
-        ],
-        "options": {
-          "buildTarget": "@fundmate-be/user-service:build",
-          "runBuildTargetDependencies": false
-        },
-        "configurations": {
-          "development": {
-            "buildTarget": "@fundmate-be/user-service:build:development"
-          },
-          "production": {
-            "buildTarget": "@fundmate-be/user-service:build:production"
-          }
-        }
-      },
-      "test": {
-        "options": {
-          "passWithNoTests": true
-        }
-      }
-    },
-    "tags": [
-      "type:app",
-      "scope:user"
-    ]
+    "dev": "cd ../.. && nx run user-service:serve:development",
+    "build": "cd ../.. && nx run user-service:build:development",
+    "test": "cd ../.. && nx test user-service"
   }
 }

--- a/apps/user-service/project.json
+++ b/apps/user-service/project.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "user-service",
+  "sourceRoot": "apps/user-service/src",
+  "projectType": "application",
+  "tags": ["type:app", "scope:ai"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "apps/user-service/dist",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/user-service/src/main.ts",
+        "tsConfig": "apps/user-service/tsconfig.app.json",
+        "assets": ["apps/user-service/src/assets"]
+      },
+      "configurations": {
+        "development": {
+          "esbuildOptions": {
+            "sourcemap": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "production",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "user-service:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "user-service:build:development",
+          "watch": true
+        },
+        "production": {
+          "buildTarget": "user-service:build:production",
+          "watch": false,
+          "inspect": false
+        }
+      }
+    },
+    "test": {
+      "options": {
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/apps/user-service/project.json
+++ b/apps/user-service/project.json
@@ -3,7 +3,7 @@
   "name": "user-service",
   "sourceRoot": "apps/user-service/src",
   "projectType": "application",
-  "tags": ["type:app", "scope:ai"],
+  "tags": ["type:app", "scope:user"],
   "targets": {
     "build": {
       "executor": "@nx/esbuild:esbuild",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "dev:all": "nx run-many -t serve"
+    "dev:all": "nx run-many -t serve --all",
+    "build:all": "nx run-many -t build --all",
+    "test:all": "nx run-many -t test --all"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## 📝 개요

- 캐싱에 상관없이 개별 서버실행과 전체 서버 실행이 가능하도록 수정함
- root > npm run [dev, test, build]:all
- 개별서버폴더 > npm run [dev, test, build]

## ✅ 작업 내용

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 🔗 관련 이슈

- 관련된 이슈 번호: #9 