### PR TITLE
hotfix: res.locals.token 추가

### DIFF
--- a/shared/config/src/lib/header-to-locals.ts
+++ b/shared/config/src/lib/header-to-locals.ts
@@ -3,12 +3,18 @@ import { Request, Response, NextFunction } from 'express';
 export function headerToLocals(req: Request, res: Response, next: NextFunction) {
   const userIdHeader = req.header('x-user-id');
   const emailHeader = req.header('x-user-email');
+  const refreshToken = req.header('x-refresh-token');
+  const accessToken = req.header('x-access-token');
   if (userIdHeader) {
     const userId = parseInt(userIdHeader, 10);
     if (!isNaN(userId)) {
       res.locals.user = {
         userId,
         email: emailHeader || '',
+      };
+      res.locals.token = {
+        refreshToken: refreshToken || '',
+        accessToken: accessToken || '',
       };
     }
   }


### PR DESCRIPTION
## 📝 개요

- locals.token에서 refreshToken과 accessToken을 꺼내서 사용할 수 있다.

## ✅ 작업 내용

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타