### PR TITLE
fix: 비밀번호 재설정 /auth/password는 토큰 검증 필요 없음

### DIFF
--- a/shared/config/src/lib/service-config.ts
+++ b/shared/config/src/lib/service-config.ts
@@ -40,7 +40,7 @@ const rowServiceConfig: Record<string, Omit<ServiceConfig, 'url' | 'host'>> = {
       { method: 'POST', path: '/auth/login', required: false },
       { method: 'POST', path: '/auth/token', required: true },
       { method: 'POST', path: '/auth/logout', required: true },
-      { method: 'PATCH', path: '/auth/password', required: true },
+      { method: 'PATCH', path: '/auth/password', required: false },
       { method: 'ALL', path: '/oauth', required: false },
     ],
   },


### PR DESCRIPTION
## 📝 개요

- /auth/password 비밀번호 재설정 api는 토큰 검증 필요하지 않아서 required: false로 수정했습니다

## ✅ 작업 내용

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타
